### PR TITLE
feat: enhance 2FA verification step with OTP input components and aut…

### DIFF
--- a/src/components/context/users/2fa/verify-code.tsx
+++ b/src/components/context/users/2fa/verify-code.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation } from "@tanstack/react-query";
-import { Loader2 } from "lucide-react";
+import { Loader2, Shield } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -13,7 +13,11 @@ import {
   FormControl,
   FormMessage,
 } from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+} from "@/components/ui/input-otp";
 import { authClient } from "@/lib/auth-client";
 
 export function VerifyStep({
@@ -26,15 +30,23 @@ export function VerifyStep({
   const form = useForm<{ code: string }>({ defaultValues: { code: "" } });
 
   const verifyMutation = useMutation({
-    mutationFn: async ({ code }: { code: string }) =>
-      authClient.twoFactor.verifyTotp({ code }),
-    onSuccess: () => {
-      toast.success("2FA activé !");
-      setStep("success");
-      onSuccess();
+    mutationFn: async ({ code }: { code: string }) => {
+      const res = await authClient.twoFactor.verifyTotp({
+        code,
+      });
+
+      if (res.data?.token) {
+        toast.success("2FA activé avec succès !");
+        setStep("success");
+        onSuccess();
+        return res.data;
+      } else {
+        throw new Error("Code de vérification invalide");
+      }
     },
-    onError: (err: Error) => {
-      toast.error(err.message || "Code invalide");
+    onError: () => {
+      toast.error("Code de vérification invalide");
+      form.setValue("code", "");
     },
   });
 
@@ -47,41 +59,78 @@ export function VerifyStep({
   };
 
   return (
-    <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-        <FormField
-          control={form.control}
-          name="code"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Code de vérification</FormLabel>
-              <FormControl>
-                <Input
-                  placeholder="123456"
-                  maxLength={6}
-                  inputMode="numeric"
-                  pattern="[0-9]*"
-                  {...field}
-                  onChange={(e) => {
-                    const value = e.target.value.replace(/\D/g, "");
-                    field.onChange(value);
-                  }}
-                  className="text-center text-lg tracking-widest"
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <div className="flex justify-end space-x-2">
-          <Button type="submit" disabled={verifyMutation.isPending}>
-            {verifyMutation.isPending && (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            )}
-            Vérifier
-          </Button>
+    <div className="space-y-6">
+      <div className="text-center space-y-2">
+        <div className="mx-auto w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
+          <Shield className="w-6 h-6 text-green-600" />
         </div>
-      </form>
-    </Form>
+        <h3 className="text-lg font-semibold">Vérifiez votre configuration</h3>
+        <p className="text-sm text-muted-foreground">
+          Saisissez le code à 6 chiffres affiché dans votre application
+          d'authentification
+        </p>
+      </div>
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <FormField
+            control={form.control}
+            name="code"
+            render={({ field }) => (
+              <FormItem className="space-y-4">
+                <FormLabel className="text-center block">
+                  Code de vérification
+                </FormLabel>
+                <FormControl>
+                  <div className="flex justify-center">
+                    <InputOTP
+                      maxLength={6}
+                      value={field.value}
+                      onChange={(value) => {
+                        field.onChange(value);
+                        // Auto-submit quand les 6 chiffres sont saisis
+                        if (value.length === 6) {
+                          form.handleSubmit(onSubmit)();
+                        }
+                      }}
+                      disabled={verifyMutation.isPending}
+                    >
+                      <InputOTPGroup>
+                        <InputOTPSlot index={0} />
+                        <InputOTPSlot index={1} />
+                        <InputOTPSlot index={2} />
+                        <InputOTPSlot index={3} />
+                        <InputOTPSlot index={4} />
+                        <InputOTPSlot index={5} />
+                      </InputOTPGroup>
+                    </InputOTP>
+                  </div>
+                </FormControl>
+                <FormMessage className="text-center" />
+              </FormItem>
+            )}
+          />
+
+          <div className="flex justify-end space-x-2">
+            <Button
+              type="submit"
+              disabled={
+                verifyMutation.isPending || form.watch("code").length !== 6
+              }
+              className="min-w-[100px]"
+            >
+              {verifyMutation.isPending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Vérification...
+                </>
+              ) : (
+                "Vérifier"
+              )}
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </div>
   );
 }


### PR DESCRIPTION
This pull request enhances the user experience for the 2FA verification step by introducing a more user-friendly interface and improving error handling. The changes include the addition of a new OTP input component, better visual feedback, and refined error messaging.

### User Interface Enhancements:
* Replaced the single `Input` component with a new `InputOTP` component, which includes `InputOTPGroup` and `InputOTPSlot` for a more structured and user-friendly OTP input experience. The new design allows automatic submission when all six digits are entered. (`[[1]](diffhunk://#diff-81522c21e95d81e094ee9fdade34c9ad99cfe3eee3c4d7675487acae30daca8aL16-R20)`, `[[2]](diffhunk://#diff-81522c21e95d81e094ee9fdade34c9ad99cfe3eee3c4d7675487acae30daca8aR62-R134)`)
* Added a visual indicator with a `Shield` icon and descriptive text to guide users during the verification process. (`[src/components/context/users/2fa/verify-code.tsxR62-R134](diffhunk://#diff-81522c21e95d81e094ee9fdade34c9ad99cfe3eee3c4d7675487acae30daca8aR62-R134)`)

### Error Handling Improvements:
* Updated the error message to provide clearer feedback when the verification code is invalid. The input field is reset upon error to prompt users to re-enter the code. (`[src/components/context/users/2fa/verify-code.tsxL29-R49](diffhunk://#diff-81522c21e95d81e094ee9fdade34c9ad99cfe3eee3c4d7675487acae30daca8aL29-R49)`)

### Code and Styling Updates:
* Adjusted the `Button` component to reflect the verification state dynamically, including a loading spinner and a disabled state when the input is incomplete or the mutation is pending. (`[src/components/context/users/2fa/verify-code.tsxR62-R134](diffhunk://#diff-81522c21e95d81e094ee9fdade34c9ad99cfe3eee3c4d7675487acae30daca8aR62-R134)`)
* Introduced a more consistent and centered layout for the form and its elements, improving overall aesthetics and usability. (`[src/components/context/users/2fa/verify-code.tsxR62-R134](diffhunk://#diff-81522c21e95d81e094ee9fdade34c9ad99cfe3eee3c4d7675487acae30daca8aR62-R134)`)